### PR TITLE
FEAT: 인스타그램 UI 변경 대응, 상위 9개 게시물 대상으로만 검색

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "instagram-popular-post-scrapper",
   "description": "instagram scrapper for popular post",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "author": {
     "name": "Yeonuk Hwang",
     "email": "charlie.hwang131@gmail.com"

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instagram-popular-post-scrapper",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "instagram scrapper for popular post",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
인스타그램 태그 검색 UI가 기존 9개 게시물 노출에서 28개 게시물 노출로 변경
기존 프로그램 동작방식에서는 28개 게시물 대상으로 검색이 진행되게 됨
클라이언트 요구사항에 맞춰 상위 9개 게시물 대상으로만 검색 및 스크린샷 촬영되도록 동작 변경
